### PR TITLE
Added disable / enable panning methods

### DIFF
--- a/src/panzoom.js
+++ b/src/panzoom.js
@@ -331,18 +331,18 @@
 		},
 		
 		/**
-		 * Enable panning 
+		 * Enable panning
 		 */
 		enablePan: function() {
 			this.options.disablePan = false;
 		},
 		
 		/**
-		 * Disable panning 
+		 * Disable panning
 		 */
 		disablePan: function() {
-			this.options.disablePan = true;		
-		},		
+			this.options.disablePan = true;
+		},
 
 		/**
 		 * Disable panzoom

--- a/src/panzoom.js
+++ b/src/panzoom.js
@@ -329,6 +329,20 @@
 			this._bind();
 			this.disabled = false;
 		},
+		
+		/**
+		 * Enable panning 
+		 */
+		enablePan: function() {
+			this.options.disablePan = false;
+		},
+		
+		/**
+		 * Disable panning 
+		 */
+		disablePan: function() {
+			this.options.disablePan = true;		
+		},		
 
 		/**
 		 * Disable panzoom


### PR DESCRIPTION
Using the plugin in conjunction with a carousel that has swipe gestures, I needed a way of enabling and disabling panning on the fly.